### PR TITLE
LINK-71 ✨ Support Binder

### DIFF
--- a/binder/environment.yml
+++ b/binder/environment.yml
@@ -1,0 +1,35 @@
+name: mrx-link-demo
+channels:
+  - conda-forge
+dependencies:
+  - python=3.9
+  - nodejs=16
+  - pip>=21
+  - pip:
+      - aiofiles>=0.8
+      - aiohttp>=3.8
+      - astor>=0.8
+      - black>=19.3b0
+      - cloudpickle>=1.6
+      - colorama>=0.4
+      - dill>=0.3
+      - isort>=5.7
+      - Jinja2>=3.0
+      - jsondiff>=2.0.0
+      - jupyter-server<=1.17.0
+      - jupyterlab>=3.1,<3.3
+      - kfp>=1.6
+      - matplotlib>=2.0
+      - nbdime>=3.1,<3.2
+      - networkx>=2.5
+      - numpy>=1.19
+      - optuna>=2.9
+      - pandas>=1.1
+      - pexpect>=4.7
+      - pycryptodome>=3.14
+      - pydantic>=1.8.0
+      - pywinpty<2.0; python_version=='3.6' and sys_platform=='win32'
+      - PyYAML>=5.4
+      - pyzmq>=17
+      - requirements-parser>=0.2
+      - sqlalchemy>=1.4

--- a/binder/postBuild
+++ b/binder/postBuild
@@ -1,0 +1,51 @@
+#!/usr/bin/env python3
+"""
+Perform a development install of mrx_link.
+
+    On Binder, this will run _after_ the environment has been fully created from
+    the environment.yml in this directory.
+
+    This script should also run locally on Linux/MacOS/Windows:
+
+        python3 binder/postBuild
+"""
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+ROOT: Path = Path.cwd()
+
+
+def _(*args: Any, **kwargs: Any) -> Any:
+    """Run a command, echoing the args
+
+    fails hard if something goes wrong
+    """
+    print("\n\t", " ".join(args), "\n")
+    return_code: int = subprocess.call(args, **kwargs)
+    if return_code != 0:
+        print("\nERROR", return_code, " ".join(args))
+        sys.exit(return_code)
+
+
+# Verify the environment is self-consistent before even starting.
+_(sys.executable, "-m", "pip", "check")
+
+# Install the labextension.
+_(sys.executable, "-m", "pip", "install", "--upgrade", "mrx_link==0.9.0.dev3")
+
+# Uninstall the labextension.
+_(sys.executable, "-m", "pip", "uninstall", "--yes", "jupyter-offlinenotebook")
+
+# Verify the environment the extension didn't break anything.
+_(sys.executable, "-m", "pip", "check")
+
+# List the extensions.
+_(sys.executable, "-m", "jupyter", "server", "extension", "list")
+
+# Initially list installed extensions to determine if there are any surprises.
+_(sys.executable, "-m", "jupyter", "labextension", "list")
+
+print("JupyterLab with mrx_link is ready to run with:\n")
+print("\tpython3 -m jupyterlab\n")


### PR DESCRIPTION
## Description
* Binder 에서 `mrx-link` 를 실행해볼 수 있습니다.

## Notes
* 현재는 `mrx-==0.9.0.dev3` 으로 하였지만, `0.9.0` 을 릴리즈 하고 수정할 필요가 있습니다.